### PR TITLE
I've corrected the Cloud SQL Proxy configuration.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -91,11 +91,9 @@ steps:
   - name: 'gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.18.0'
     id: 'cloud-sql-proxy'
     waitFor: ['build-campaigns-backend']
-    entrypoint: 'sh'
     args:
-      - '-c'
-      - '/cloud_sql_proxy --unix-socket=/cloudsql $$DB_CONNECTION_NAME'
-    secretEnv: ['DB_CONNECTION_NAME']
+      - '--unix-socket=/cloudsql'
+    secretEnv: ['CLOUD_SQL_INSTANCES']
 
   # Step 7: Run Database Migrations using a secret for the DATABASE_URL
   - name: 'gcr.io/google-appengine/exec-wrapper'
@@ -131,6 +129,8 @@ availableSecrets:
   secretManager:
   - versionName: projects/cerberus-data-cloud/secrets/DB_CONNECTION_NAME/versions/latest
     env: 'DB_CONNECTION_NAME'
+  - versionName: projects/cerberus-data-cloud/secrets/DB_CONNECTION_NAME/versions/latest
+    env: 'CLOUD_SQL_INSTANCES'
   - versionName: projects/cerberus-data-cloud/secrets/DB_USER/versions/latest
     env: 'DB_USER'
   - versionName: projects/cerberus-data-cloud/secrets/DB_PASS/versions/latest


### PR DESCRIPTION
The cloud build was failing because the `cloud-sql-proxy` step was attempting to use `entrypoint: 'sh'` on a distroless container image that does not include a shell. This resulted in an `exec: "sh": executable file not found` error.

I fixed the issue by:
1.  Removing the `entrypoint: 'sh'` and the associated shell command from the `cloud-sql-proxy` build step.
2.  Configuring the proxy to read the instance connection name from the `CLOUD_SQL_INSTANCES` environment variable, which is supported by this version of the proxy.
3.  Updating the `availableSecrets` section to expose the `DB_CONNECTION_NAME` secret as the `CLOUD_SQL_INSTANCES` environment variable for the proxy step to consume.