### PR TITLE
Fix(cloudbuild): Correct Cloud SQL Proxy configuration using exec-wra…

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -88,13 +88,19 @@ steps:
     ]
 
   # Step 6: Run Cloud SQL Proxy
-  - name: 'gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.18.0'
+  - name: 'gcr.io/google-appengine/exec-wrapper'
     id: 'cloud-sql-proxy'
     waitFor: ['build-campaigns-backend']
-    entrypoint: 'sh'
-    args:
-      - '-c'
-      - '/cloud_sql_proxy --unix-socket=/cloudsql $$DB_CONNECTION_NAME'
+    args: [
+        '-i',
+        'gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.18.0',
+        '-e',
+        'DB_CONNECTION_NAME=$$(DB_CONNECTION_NAME)',
+        '--',
+        '/cloud_sql_proxy',
+        '--unix-socket=/cloudsql',
+        '$DB_CONNECTION_NAME'
+    ]
     secretEnv: ['DB_CONNECTION_NAME']
 
   # Step 7: Run Database Migrations using a secret for the DATABASE_URL


### PR DESCRIPTION
…pper

The cloud build was failing because the `cloud-sql-proxy` step was attempting to use `entrypoint: 'sh'` on a distroless container image that does not include a shell. This resulted in an `exec: "sh": executable file not found` error.

This commit fixes the issue by using the `gcr.io/google-appengine/exec-wrapper` to run the `cloud-sql-proxy`. This approach is consistent with the `run-migrations` step in the same file and correctly handles the expansion of the `DB_CONNECTION_NAME` secret as a command-line argument to the proxy.