### PR TITLE
Fix(cloudbuild): Use shell-based builder for Cloud SQL Proxy

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -88,13 +88,16 @@ steps:
     ]
 
   # Step 6: Run Cloud SQL Proxy
-  - name: 'gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.18.0'
+  - name: 'gcr.io/cloud-builders/gcloud'
     id: 'cloud-sql-proxy'
     waitFor: ['build-campaigns-backend']
-    entrypoint: 'sh'
+    entrypoint: 'bash'
     args:
       - '-c'
-      - '/cloud_sql_proxy --unix-socket=/cloudsql $$DB_CONNECTION_NAME'
+      - |
+        wget https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.0/cloud-sql-proxy.linux.amd64 -O /workspace/cloud_sql_proxy
+        chmod +x /workspace/cloud_sql_proxy
+        /workspace/cloud_sql_proxy --unix-socket=/cloudsql/ $$DB_CONNECTION_NAME &
     secretEnv: ['DB_CONNECTION_NAME']
 
   # Step 7: Run Database Migrations using a secret for the DATABASE_URL


### PR DESCRIPTION
The cloud build was failing because the `cloud-sql-proxy` step was attempting to use `entrypoint: 'sh'` on a distroless container image that does not include a shell.

This commit fixes the issue by using the `gcr.io/cloud-builders/gcloud` builder, which includes a shell. A bash script is now used to download the `cloud-sql-proxy` binary, make it executable, and launch it in the background. This ensures that the proxy is running for the subsequent steps that depend on it.