### PR TITLE
I removed the duplicate secret definition for `DB_CONNECTION_NAME` fr…

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -134,8 +134,6 @@ availableSecrets:
   secretManager:
   - versionName: projects/cerberus-data-cloud/secrets/DB_CONNECTION_NAME/versions/latest
     env: 'DB_CONNECTION_NAME'
-  - versionName: projects/cerberus-data-cloud/secrets/DB_CONNECTION_NAME/versions/latest
-    env: 'CLOUD_SQL_INSTANCES'
   - versionName: projects/cerberus-data-cloud/secrets/DB_USER/versions/latest
     env: 'DB_USER'
   - versionName: projects/cerberus-data-cloud/secrets/DB_PASS/versions/latest


### PR DESCRIPTION
…om the `availableSecrets` section in your `cloudbuild.yaml` file. This was causing your cloud build to fail with an `INVALID_ARGUMENT` error.