### PR TITLE
I've fixed your Cloud Build pipeline by addressing two critical errors:

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -88,32 +88,28 @@ steps:
     ]
 
   # Step 6: Run Cloud SQL Proxy
-  - name: 'gcr.io/cloud-builders/gcloud'
+  - name: 'gcr.io/cloud-builders/curl'
     id: 'cloud-sql-proxy'
     waitFor: ['build-campaigns-backend']
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        wget https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.0/cloud-sql-proxy.linux.amd64 -O /workspace/cloud_sql_proxy
+        curl -o /workspace/cloud_sql_proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.0/cloud-sql-proxy.linux.amd64
         chmod +x /workspace/cloud_sql_proxy
-        /workspace/cloud_sql_proxy --unix-socket=/cloudsql/ $$DB_CONNECTION_NAME &
+        /workspace/cloud_sql_proxy --unix-socket=/cloudsql/ $$DB_CONNECTION_NAME & wait $!
     secretEnv: ['DB_CONNECTION_NAME']
 
-  # Step 7: Run Database Migrations using a secret for the DATABASE_URL
-  - name: 'gcr.io/google-appengine/exec-wrapper'
+  # Step 7: Run Database Migrations
+  - name: 'us-south1-docker.pkg.dev/cerberus-data-cloud/cerberus-images/campaigns-api:$SHORT_SHA'
     id: 'run-migrations'
     waitFor: ['cloud-sql-proxy']
-    args: [
-      '-i', 'us-south1-docker.pkg.dev/cerberus-data-cloud/cerberus-images/campaigns-api:$SHORT_SHA',
-      '-e', 'FLASK_ENV=production',
-      '-e', 'DATABASE_URL=postgresql+psycopg://$$(DB_USER):$$(DB_PASS)@/$$(DB_NAME)?host=/cloudsql/$$(DB_CONNECTION_NAME)',
-      '--',
-      'flask',
-      'db',
-      'upgrade'
-    ]
+    entrypoint: 'flask'
+    args: ['db', 'upgrade']
     secretEnv: ['DB_USER', 'DB_PASS', 'DB_NAME', 'DB_CONNECTION_NAME']
+    env:
+      - 'FLASK_ENV=production'
+      - 'DATABASE_URL=postgresql+psycopg://$$(DB_USER):$$(DB_PASS)@/$$(DB_NAME)?host=/cloudsql/$$(DB_CONNECTION_NAME)'
 
 # List of images to be pushed to Artifact Registry
 images:


### PR DESCRIPTION
1.  The `cloud-sql-proxy` step failed because the `gcr.io/cloud-builders/gcloud` image does not contain `wget`. I updated this step to use `gcr.io/cloud-builders/curl` and started the proxy in a way that ensures it remains running for subsequent steps.

2.  The `run-migrations` step failed with an `invalid reference format` error. I refactored this step to use the just-built Docker image directly, which is a more modern and reliable pattern than the previous `exec-wrapper` implementation.