### PR TITLE
fix(campaigns-backend): Use psycopg3 in test DB connection

### DIFF
--- a/cerberus_campaigns_backend/docker-compose.test.yaml
+++ b/cerberus_campaigns_backend/docker-compose.test.yaml
@@ -8,7 +8,7 @@ services:
       - db
     environment:
       - FLASK_ENV=testing
-      - DATABASE_URL=postgresql://test_user:test_password@db:5432/test_db
+      - DATABASE_URL=postgresql+psycopg://test_user:test_password@db:5432/test_db
     command: ["sh", "-c", "pip install -r requirements-dev.txt && pytest"]
   db:
     image: postgis/postgis:13-3.4


### PR DESCRIPTION
The tests for `cerberus_campaigns_backend` were failing with a `ModuleNotFoundError: No module named 'psycopg2'`.

This was because the `requirements.txt` installs `psycopg[binary]` (which provides the `psycopg` v3 driver), but the `DATABASE_URL` in `docker-compose.test.yaml` was using the `postgresql://` scheme, which makes SQLAlchemy default to the `psycopg2` driver.

This change updates the `DATABASE_URL` in `docker-compose.test.yaml` to use the `postgresql+psycopg://` scheme, which correctly instructs SQLAlchemy to use the installed `psycopg` v3 driver.