### PR TITLE
feat: Refactor Flutter app to be configuration-driven

### DIFF
--- a/universal_campaign_frontend/lib/config/config_loader.dart
+++ b/universal_campaign_frontend/lib/config/config_loader.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'dart:html' if (dart.library.io) 'package:universal_campaign_frontend/config/mock_html.dart';
+
+import 'campaign_config.dart';
+import 'campaigns.dart';
+
+CampaignConfig? getCampaignConfig() {
+  String hostname;
+  if (kIsWeb) {
+    hostname = window.location.hostname!;
+  } else {
+    // For non-web, which includes local development, we'll use a placeholder.
+    // This logic assumes non-web execution is for development/testing.
+    hostname = 'localhost';
+  }
+
+  if (hostname == 'localhost' || hostname == '127.0.0.1') {
+    // Per instructions, default to 'emmons' for local development.
+    return campaigns['emmons'];
+  }
+
+  // Find the campaign that matches the domain.
+  for (final campaign in campaigns.values) {
+    if (campaign.domain == hostname) {
+      return campaign;
+    }
+  }
+
+  // If no match is found, return null.
+  return null;
+}

--- a/universal_campaign_frontend/lib/config/mock_html.dart
+++ b/universal_campaign_frontend/lib/config/mock_html.dart
@@ -1,0 +1,12 @@
+// A mock implementation of dart:html for non-web platforms.
+// This allows the config_loader to compile and run in a mobile or desktop environment.
+
+class MockWindow {
+  final MockLocation location = MockLocation();
+}
+
+class MockLocation {
+  String? get hostname => null;
+}
+
+final MockWindow window = MockWindow();

--- a/universal_campaign_frontend/lib/main.dart
+++ b/universal_campaign_frontend/lib/main.dart
@@ -1,25 +1,48 @@
 import 'package:flutter/material.dart';
+import 'package:universal_campaign_frontend/config/campaign_config.dart';
+import 'package:universal_campaign_frontend/config/config_loader.dart';
+import 'package:universal_campaign_frontend/pages/error_page.dart';
+import 'package:universal_campaign_frontend/pages/home_page.dart';
 
 void main() {
-  runApp(const MyApp());
+  final CampaignConfig? config = getCampaignConfig();
+  runApp(MyApp(config: config));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final CampaignConfig? config;
+
+  const MyApp({super.key, this.config});
 
   @override
   Widget build(BuildContext context) {
+    // If config is null, the app is not configured for the current domain.
+    // Show a MaterialApp with the ErrorPage as the home.
+    if (config == null) {
+      return const MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: ErrorPage(
+          message: 'This domain is not configured for any campaign.',
+        ),
+      );
+    }
+
+    // If a config is found, build the full-featured MaterialApp.
     return MaterialApp(
-      title: 'Universal Campaign Frontend',
+      debugShowCheckedModeBanner: false,
+      title: config!.siteTitle,
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        fontFamily: config!.theme.fontFamily,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: config!.theme.primaryColor,
+          primary: config!.theme.primaryColor,
+          secondary: config!.theme.secondaryColor,
+          brightness: Brightness.light, // Or determine from config
+        ),
         useMaterial3: true,
       ),
-      home: const Scaffold(
-        body: Center(
-          child: Text('Hello, World!'),
-        ),
-      ),
+      // The home property is now the new HomePage, which is config-driven.
+      home: HomePage(config: config!),
     );
   }
 }

--- a/universal_campaign_frontend/lib/pages/error_page.dart
+++ b/universal_campaign_frontend/lib/pages/error_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class ErrorPage extends StatelessWidget {
+  final String? message;
+
+  const ErrorPage({super.key, this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(
+                Icons.error_outline,
+                color: Colors.red,
+                size: 80,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                'Configuration Error',
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                message ??
+                    'There was a problem loading the campaign configuration for this domain. Please contact support.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/universal_campaign_frontend/lib/pages/home_page.dart
+++ b/universal_campaign_frontend/lib/pages/home_page.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:universal_campaign_frontend/config/campaign_config.dart';
+
+class HomePage extends StatelessWidget {
+  final CampaignConfig config;
+
+  const HomePage({super.key, required this.config});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        title: Image.network(
+          config.theme.logoUrl,
+          height: 40,
+          fit: BoxFit.contain,
+          // Provide a specific error message as requested
+          errorBuilder: (context, error, stackTrace) {
+            return const Text(
+              'Error: Logo image could not be loaded.',
+              style: TextStyle(color: Colors.red, fontSize: 14),
+            );
+          },
+          // A loading builder can improve user experience
+          loadingBuilder: (context, child, loadingProgress) {
+            if (loadingProgress == null) return child;
+            return const Center(child: CircularProgressIndicator());
+          },
+        ),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const SizedBox(height: 40),
+              Text(
+                config.content.heroTitle,
+                style: textTheme.headlineLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: config.theme.primaryColor,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                config.content.heroSubtitle,
+                style: textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 40),
+              ElevatedButton(
+                onPressed: () {
+                  // TODO: Implement navigation or action for the CTA
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: config.theme.primaryColor,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 48,
+                    vertical: 20,
+                  ),
+                  textStyle: textTheme.titleMedium,
+                ),
+                child: Text(config.content.callToActionLabel),
+              ),
+              const SizedBox(height: 60),
+              // We can add sections for Issues and Endorsements here later
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This commit introduces a configuration-driven architecture for the Flutter application.

The `main.dart` file has been modified to use a new `ConfigLoader` service. This service detects the browser's hostname at runtime and loads the corresponding `CampaignConfig` from a predefined map. This allows the application to serve different campaign branding and content from a single codebase.

A new `HomePage` widget has been created to replace the previous placeholder content. This page is now fully dynamic, consuming all its data (text, colors, images) from the loaded `CampaignConfig` object.

To handle cases where a domain is not configured, an `ErrorPage` has been added to provide a clear error message to you. For local development, the application defaults to loading the 'emmons' campaign when accessed via `localhost`.

This change addresses the need to move away from a hardcoded frontend and towards a more scalable, multi-tenant solution.